### PR TITLE
feat: also replace lastRelease.version in files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 const { join } = require("path");
 const debug = require("debug")("semantic-release:update-version-in-files");
 
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 module.exports = {
   prepare(
     {
@@ -10,13 +14,20 @@ module.exports = {
       fs = require("fs"),
       glob = require("glob"),
     },
-    { cwd, nextRelease: { version } },
+    { cwd, nextRelease: { version }, lastRelease },
   ) {
     debug("config %o", { files, placeholder });
     debug("nextRelease.version %s", version);
+    debug("lastRelease.version %s", lastRelease?.version);
 
-    // Turn placeholder string into regex
-    const searchRegex = new RegExp(placeholder, "g");
+    // Search for placeholder and, when available, the previous release version
+    const searchRegex = new RegExp(
+      [placeholder, lastRelease?.version]
+        .filter(Boolean)
+        .map(escapeRegExp)
+        .join("|"),
+      "g",
+    );
 
     // Normalize files parameter and prefix with root path
     const filesNormalized = Array.isArray(files) ? files : [files];

--- a/test.js
+++ b/test.js
@@ -252,3 +252,39 @@ test("custom search", (t) => {
   t.match(newContent, /1.2.3/, "Version updated in /version.js");
   t.end();
 });
+
+test("replaces lastRelease.version", (t) => {
+  const files = {
+    "version.js": Buffer.from("module.exports = '2.0.0-beta.1'"),
+  };
+  const fs = new MemoryFileSystem(files);
+
+  prepare(
+    {
+      fs,
+      glob: {
+        sync() {
+          return ["/version.js"];
+        },
+      },
+    },
+    {
+      cwd: "",
+      nextRelease: {
+        version: "2.0.0-beta.2",
+      },
+      lastRelease: {
+        version: "2.0.0-beta.1",
+      },
+      logger: {
+        error: (message) => t.fail(message),
+        log() {},
+        success() {},
+      },
+    },
+  );
+
+  const newContent = fs.readFileSync("/version.js", "utf8");
+  t.equal(newContent, "module.exports = '2.0.0-beta.2'");
+  t.end();
+});


### PR DESCRIPTION
Previously, the plugin only searched for the static `placeholder` string (default `0.0.0-development`). After the first release replaced it, subsequent releases — including pre-releases on channels like `beta` — had nothing to match and couldn't update the version in files.

This adds `lastRelease.version` (provided by semantic-release) as an additional search pattern alongside the placeholder. Both patterns are now regex-escaped to prevent partial matches (e.g., `2.0.0-beta.1` accidentally matching inside `2.0.0-beta.10`).

Closes #52